### PR TITLE
✨ Add a command to dynamically generate various shell completion scri…

### DIFF
--- a/crates/cli/src/commands/completion_script/mod.rs
+++ b/crates/cli/src/commands/completion_script/mod.rs
@@ -1,0 +1,34 @@
+//! Generate tab-completion scripts for different types of shells.
+
+use anyhow::Result;
+use clap::{App, SubCommand, Arg, ArgMatches, AppSettings};
+use clap::Shell;
+use clap::value_t;
+use crate::{build_cli, BIN_NAME};
+use std::io;
+
+/// command
+pub(crate) fn cmd<'a, 'b>() -> App<'a, 'b> {
+    SubCommand::with_name("generate-shell-completions")
+        .alias("gsc")
+        .about("Prints the completion script dedicated to the CLI for a given shell")
+        .setting(AppSettings::ArgRequiredElseHelp)
+        .args(&[
+            Arg::with_name("shell")
+                .help("Type of shell to generate the completion script for.")
+                .required(true)
+                .takes_value(true)
+                .possible_values(&Shell::variants())
+                .case_insensitive(true)
+                .value_name("SHELL"),
+        ])
+}
+
+/// handler
+pub(crate) fn handle_cmd(matches: &ArgMatches) -> Result<()> {
+    if let Ok(generator) = value_t!(matches, "shell", Shell) {
+        let mut app = build_cli();
+        app.gen_completions_to(BIN_NAME, generator, &mut io::stdout());
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod project;
 pub mod shaper;
 pub mod source;
 pub mod transformation;
+pub mod completion_script;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -14,25 +14,11 @@ mod utils;
 
 fn main() {
     // Create CLI matches
-    let matches = App::new("Holium")
-        .bin_name("holium")
-        .version(crate_version!())
-        .author(crate_authors!("\n"))
-        .about("Enjoy the power of the Holium Framework")
-        .setting(AppSettings::ArgRequiredElseHelp)
-        .subcommands(vec![
-            commands::init::cmd(),
-            commands::source::cmd(),
-            commands::shaper::cmd(),
-            commands::transformation::cmd(),
-            commands::connection::cmd(),
-            commands::portation::cmd(),
-            commands::project::cmd(),
-        ])
-        .get_matches();
+    let matches = build_cli().get_matches();
 
     // Match subcommands
     let exec_res = match matches.subcommand() {
+        ("generate-shell-completions", Some(matches)) => commands::completion_script::handle_cmd(matches),
         ("init", Some(matches)) => commands::init::handle_cmd(matches),
         ("source", Some(matches)) => commands::source::handle_cmd(matches),
         ("shaper", Some(matches)) => commands::shaper::handle_cmd(matches),
@@ -51,4 +37,25 @@ fn main() {
             1
         }
     })
+}
+
+pub const BIN_NAME: &str = "holium";
+
+pub fn build_cli() -> App<'static, 'static> {
+    App::new("Holium")
+        .bin_name(BIN_NAME)
+        .version(crate_version!())
+        .author(crate_authors!("\n"))
+        .about("Enjoy the power of the Holium Framework")
+        .setting(AppSettings::ArgRequiredElseHelp)
+        .subcommands(vec![
+            commands::completion_script::cmd(),
+            commands::init::cmd(),
+            commands::source::cmd(),
+            commands::shaper::cmd(),
+            commands::transformation::cmd(),
+            commands::connection::cmd(),
+            commands::portation::cmd(),
+            commands::project::cmd(),
+        ])
 }


### PR DESCRIPTION
### What It Does 🔎
<!-- A concise description of what this pull request does. -->

✨ Add a command to dynamically generate completion scripts for various types of shell.

### Documentation Updates 📘
<!-- Any specific updates to the documentation ? -->

### How To Test ✔️
<!--
Example: steps to acces new features:
1. In this context...
2. Run '...'
4. See behavior...
-->

`cargo build to build`

Then you may load the script with (for bash):

```bash
eval "$(holium gsc bash)"
```

You can then type `holium <TAB>` to see it in action.


### Linked Issues 🎫
<!-- You may use the [appropriated syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close or resolve linked issues. -->

There seems to be an error with this _auto-generation_ feature for our app and with `zsh`, but I would suggest to keep it that way as it may be fixed in future releases of `clap` in the future.
  
### Related Pull Requests 🔀
<!-- Any other pull request somehow related to this new one ? -->

