### PR TITLE
:bug: Fixed json ordering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holium"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 authors = ["Polyphene <contact@polyphene.io>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ prettytable-rs = "^0.8.0"
 serde = { version = "^1.0.126", features = ["derive"] }
 serde_cbor = "^0.11.1"
 serde_derive = "^1.0.126"
-serde_json = "^1.0.66"
+serde_json = { version = "^1.0.66", features = ["preserve_order"] }
 serde_yaml = "^0.8.21"
 sk-cbor = "^0.1.2"
 sled = "^0.34.7"

--- a/src/utils/local/helpers/prints/json/mod.rs
+++ b/src/utils/local/helpers/prints/json/mod.rs
@@ -36,7 +36,7 @@ mod test {
         // Non prettify JSON
         let string = "{\"type\": \"array\", \"prefixItems\": [{\"type\": \"string\"}]}";
         // We add indentation and return to line to have a pretty formatting
-        let expected_result = "{\n  \"prefixItems\": [\n    {\n      \"type\": \"string\"\n    }\n  ],\n  \"type\": \"array\"\n}";
+        let expected_result = "{\n  \"type\": \"array\",\n  \"prefixItems\": [\n    {\n      \"type\": \"string\"\n    }\n  ]\n}";
 
         // Format JSON
         let result_string = shorten_prettify_json_literal(string);

--- a/src/utils/run/runtime/mod.rs
+++ b/src/utils/run/runtime/mod.rs
@@ -107,9 +107,8 @@ impl Runtime {
         // Because of legacy from SDK we need to convert to Data Node before sending off payload.
         // TODO fix when sdk is corrected with custom serde
         let serde_value: serde_cbor::Value = serde_cbor::from_slice(data).unwrap();
-        let data_tree = crate::utils::run::data::data_tree::Node::new(serde_value);
+        let data_tree = crate::utils::run::data::data_tree::Node::new(serde_value)?;
         let payload_cbor: Vec<u8> = serde_cbor::to_vec(&data_tree).unwrap();
-
         // Get module linear memory
         let memory = self.memory()?;
 
@@ -145,6 +144,7 @@ impl Runtime {
 
         let res_node: crate::utils::run::data::data_tree::Node =
             serde_cbor::from_slice(&node_bytes_payload).unwrap();
+
         Ok(serde_cbor::to_vec(&serde_cbor::Value::from(res_node)).unwrap())
     }
 


### PR DESCRIPTION
Fixed json ordering when importing data using portation. Done with serde_json preserve_order feature

### What It Does 🔎
<!-- A concise description of what this pull request does. -->
Fixing JSON ordering when importing a JSON file using portations. Necessary for selectors afterwards.

### Documentation Updates 📘
<!-- Any specific updates to the documentation ? -->
N/A

### How To Test ✔️
<!--
Example: steps to access new features:
1. In this context...
2. Run '...'
4. See behavior...
-->
N/A

### Linked Issues 🎫
<!-- You may use the [appropriated syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to close or resolve linked issues. -->
N/A

### Related Pull Requests 🔀
<!-- Any other pull request somehow related to this new one ? -->
N/A